### PR TITLE
Attachments capability to slack message

### DIFF
--- a/slack.js
+++ b/slack.js
@@ -28,6 +28,7 @@ Slack.prototype.send = function(message,cb) {
 
   if( message.icon_emoji ) options.icon_emoji = message.icon_emoji;
   if( message.icon_url ) options.icon_url = message.icon_url;
+  if( message.attachments ) options.attachments = message.attachments;
 
   var requestParams = {
     url: url,

--- a/test/testSlack.js
+++ b/test/testSlack.js
@@ -18,11 +18,19 @@ describe('test send', function(){
       channel: 'test',
       text: 'hello',
       username: 'test',
-      icon_emoji: 'smile'
+      icon_emoji: 'smile',
+      attachments : [{ 
+        fallback: 'hello',
+        color: 'good',
+        fields: [
+          {title: 'col 1', value: 'hello 1', short: true},
+          {title: 'col 2', value: 'hello 2', short: true}
+        ]
+      }]
     };
     var expected = {
       url: 'https://testing.slack.com/services/hooks/incoming-webhook?token=testToken',
-      body: '{"channel":"#test","text":"hello","username":"test","icon_emoji":"smile"}'
+      body: '{"channel":"#test","text":"hello","username":"test","icon_emoji":"smile","attachments":[{"fallback":"hello","color":"good","fields":[{"title":"col 1","value":"hello 1","short":true},{"title":"col 2","value":"hello 2","short":true}]}]}'
     };
     request.post.callsArgWith(1, null, null, 'ok');
     slack.send(input, function(err, res){


### PR DESCRIPTION
Added attachment option for slack message send to enable richer formatting. Updated test.

![image](https://cloud.githubusercontent.com/assets/2839047/3098680/75266bac-e5ef-11e3-80f3-56e04080d839.png)
