### PR TITLE
Remove hash character auto-add.

### DIFF
--- a/slack.js
+++ b/slack.js
@@ -19,7 +19,6 @@ Slack.prototype.send = function(message,cb) {
 
   var url = 'https://' + this.domain + '.slack.com/services/hooks/incoming-webhook?token=' + this.token;
   var channel = message.channel || this.defaultChannel;
-  if(channel.substring(0,1) !== '#') channel = '#' + channel;
   var options = {
     channel: channel,
     text: message.text,

--- a/test/testSlack.js
+++ b/test/testSlack.js
@@ -15,7 +15,7 @@ describe('test send', function(){
 
   it('should callback with ok', function(done){
     var input = {
-      channel: 'test',
+      channel: '#test',
       text: 'hello',
       username: 'test',
       icon_emoji: 'smile',


### PR DESCRIPTION
Remove code which adds '#' character to channel name to prevent direct messages from throwing invalid channel error.
