### PR TITLE
Allow messages without 'text'

### DIFF
--- a/slack.js
+++ b/slack.js
@@ -12,7 +12,7 @@ function Slack(options) {
 }
 
 Slack.prototype.send = function(message,cb) {
-  if( !( message && message instanceof Object && message.text ) ) {
+  if( !( message && message instanceof Object && ( message.text || message.attachments ) ) ) {
     if( cb && cb instanceof Function ) return cb(new Error('No message'));
     return 'No message';
   }
@@ -21,10 +21,10 @@ Slack.prototype.send = function(message,cb) {
   var channel = message.channel || this.defaultChannel;
   var options = {
     channel: channel,
-    text: message.text,
-    username: message.username,
+    username: message.username
   };
 
+  if( message.text ) options.text = message.text;
   if( message.icon_emoji ) options.icon_emoji = message.icon_emoji;
   if( message.icon_url ) options.icon_url = message.icon_url;
   if( message.attachments ) options.attachments = message.attachments;

--- a/test/testSlack.js
+++ b/test/testSlack.js
@@ -30,7 +30,7 @@ describe('test send', function(){
     };
     var expected = {
       url: 'https://testing.slack.com/services/hooks/incoming-webhook?token=testToken',
-      body: '{"channel":"#test","text":"hello","username":"test","icon_emoji":"smile","attachments":[{"fallback":"hello","color":"good","fields":[{"title":"col 1","value":"hello 1","short":true},{"title":"col 2","value":"hello 2","short":true}]}]}'
+      body: '{"channel":"#test","username":"test","text":"hello","icon_emoji":"smile","attachments":[{"fallback":"hello","color":"good","fields":[{"title":"col 1","value":"hello 1","short":true},{"title":"col 2","value":"hello 2","short":true}]}]}'
     };
     request.post.callsArgWith(1, null, null, 'ok');
     slack.send(input, function(err, res){
@@ -49,7 +49,7 @@ describe('test send', function(){
     };
     var expected = {
       url: 'https://testing.slack.com/services/hooks/incoming-webhook?token=testToken',
-      body: '{"channel":"#general","text":"hello","username":"test","icon_url":"drnick.png"}'
+      body: '{"channel":"#general","username":"test","text":"hello","icon_url":"drnick.png"}'
     };
     request.post.callsArgWith(1, null, null, 'ok');
     slack.send(input, function(err, res){
@@ -70,6 +70,33 @@ describe('test send', function(){
     });
   });
 
+  it('should allow messages with attachments without text', function(done){
+    var input = {
+      channel: '#test',
+      username: 'test',
+      icon_emoji: 'smile',
+      attachments : [{ 
+        fallback: 'hello',
+        color: 'good',
+        fields: [
+          {title: 'col 1', value: 'hello 1', short: true},
+          {title: 'col 2', value: 'hello 2', short: true}
+        ]
+      }]
+    };
+    var expected = {
+      url: 'https://testing.slack.com/services/hooks/incoming-webhook?token=testToken',
+      body: '{"channel":"#test","username":"test","icon_emoji":"smile","attachments":[{"fallback":"hello","color":"good","fields":[{"title":"col 1","value":"hello 1","short":true},{"title":"col 2","value":"hello 2","short":true}]}]}'
+    };
+    request.post.callsArgWith(1, null, null, 'ok');
+    slack.send(input, function(err, res){
+      assert.ok(!err);
+      assert.equal(res, 'ok');
+      assert.deepEqual(request.post.getCall(0).args[0], expected);
+      done();
+    });
+  });
+    
   afterEach(function(){
     request.post.restore();
   });


### PR DESCRIPTION
If an attachment is used, you may not always want to send text with the message.  Slack's hook API supports this.
